### PR TITLE
【修复】修复read函数返回值恒为0，返回正确读出长度。

### DIFF
--- a/samples/porting/fal_flash_stm32f2_port.c
+++ b/samples/porting/fal_flash_stm32f2_port.c
@@ -136,8 +136,9 @@ static int init(void)
 
 static int read(long offset, uint8_t *buf, size_t size)
 {
+    size_t i;
     uint32_t addr = stm32f2_onchip_flash.addr + offset;
-    for (; size > 0; size -= 1, addr += 1, buf++)
+    for (i = 0; i < size; i++, addr++, buf++)
     {
         *buf = *(uint8_t *) addr;
     }


### PR DESCRIPTION
Signed-off-by: camel <camel.bacck@163.com>