### PR TITLE
【修复】fal 分区表打印对齐问题

### DIFF
--- a/inc/fal_def.h
+++ b/inc/fal_def.h
@@ -92,7 +92,7 @@ if (!(EXPR))                                                                   \
 #ifdef  log_i
 #undef  log_i
 #endif
-#define log_i(...)                     printf("\033[36;22m[I/FAL] ");                                printf(__VA_ARGS__);printf("\033[0m\n")
+#define log_i(...)                     printf("\033[32;22m[I/FAL] ");                                printf(__VA_ARGS__);printf("\033[0m\n")
 
 /* FAL flash and partition device name max length */
 #ifndef FAL_DEV_NAME_MAX

--- a/src/fal.c
+++ b/src/fal.c
@@ -36,6 +36,8 @@ int fal_init(void)
     extern int fal_partition_init(void);
 
     int result;
+    static uint8_t init_ok = 0;
+
     /* initialize all flash device on FAL flash table */
     result = fal_flash_init();
 
@@ -48,12 +50,14 @@ int fal_init(void)
 
 __exit:
 
-    if (result > 0)
+    if ((result > 0) && (!init_ok))
     {
+        init_ok = 1;
         log_i("RT-Thread Flash Abstraction Layer (V%s) initialize success.", FAL_SW_VERSION);
     }
-    else
+    else if(result <= 0)
     {
+        init_ok = 0;
         log_e("RT-Thread Flash Abstraction Layer (V%s) initialize failed.", FAL_SW_VERSION);
     }
 

--- a/src/fal_partition.c
+++ b/src/fal_partition.c
@@ -90,7 +90,7 @@ void fal_show_part_table(void)
             part = &partition_table[i];
             if (strlen(part->name) > part_name_max)
             {
-                part_name_max = strlen(part->flash_name);
+                part_name_max = strlen(part->name);
             }
             if (strlen(part->flash_name) > flash_dev_name_max)
             {


### PR DESCRIPTION
【修复】fal 分区表打印对齐问题
【更新】fal info log 颜色为 32，与 RT-Thread 统一

Signed-off-by: MurphyZhao <d2014zjt@163.com>