### PR TITLE
增加fal_init函数在rtt下可选择为自动初始化方式

### DIFF
--- a/inc/fal_def.h
+++ b/inc/fal_def.h
@@ -112,7 +112,7 @@ struct fal_flash_dev
         int (*erase)(long offset, size_t size);
     } ops;
 
-    /* write minimum granularity, unit: bit. 
+    /* write minimum granularity, unit: bit.
        1(nor flash)/ 8(stm32f2/f4)/ 32(stm32f1)/ 64(stm32l4)
        0 will not take effect. */
     size_t write_gran;

--- a/src/fal.c
+++ b/src/fal.c
@@ -56,7 +56,7 @@ INIT_ENV_EXPORT(fal_init);
 
 /**
  * Check if the FAL is initialized successfully
- * 
+ *
  * @return 0: not init or init failed; 1: init success
  */
 int fal_init_check(void)

--- a/src/fal.c
+++ b/src/fal.c
@@ -50,6 +50,9 @@ __exit:
 
     return result;
 }
+#if defined(__RTTHREAD__) && defined(FAL_USING_AUTO_INIT)
+INIT_ENV_EXPORT(fal_init);
+#endif
 
 /**
  * Check if the FAL is initialized successfully

--- a/src/fal_rtt.c
+++ b/src/fal_rtt.c
@@ -274,7 +274,7 @@ static rt_err_t mtd_nor_dev_erase(struct rt_mtd_nor_device* device, rt_off_t off
     }
 }
 
-static const struct rt_mtd_nor_driver_ops _ops = 
+static const struct rt_mtd_nor_driver_ops _ops =
 {
     RT_NULL,
     mtd_nor_dev_read,


### PR DESCRIPTION
默认为不自动初始化，以兼容老版本